### PR TITLE
Fixes calling the provided onDrop-function with no files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,7 @@ class Dropzone extends React.Component {
         rejectedFiles.push(...acceptedFiles.splice(0))
       }
 
-      if (onDrop) {
+      if (onDrop && (acceptedFiles.length > 0 || rejectedFiles.length > 0)) {
         onDrop.call(this, acceptedFiles, rejectedFiles, evt)
       }
 


### PR DESCRIPTION
We had an issue where the onDrop method (provided as a prop) was called with empty lists for both accepted and rejected files.

This is related to this issue: https://github.com/facebook/react/issues/8793
This is a workaround, there might be a prettier way to fix this.